### PR TITLE
Add contributing and docbuild docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -11,6 +11,7 @@ makedocs(;
                 canonical="https://rightleftspin.github.io/Lincege.jl",
                 edit_link="main",
                 assets=String[],
+                prettyurls=false,
         ),
         pages=[
                 "Home" => "index.md",
@@ -20,6 +21,10 @@ makedocs(;
                         "Pyrochlore Lattice Unit Cell" => "examples/pyrochlore_unit_cell_expansion.md",
                         "Square Lattice Cluster" => "examples/square_cluster.md",
                 ],
+                "Development" => [
+                        "Contributing" => "dev/contributing.md",
+                        "Building the Docs" => "dev/building_docs.md",
+                        ],
         ],
 )
 

--- a/docs/src/dev/building_docs.md
+++ b/docs/src/dev/building_docs.md
@@ -1,0 +1,24 @@
+# Building the Documentation for Lincege.jl
+
+To build the docs locally, run `make.jl` from the `docs/` directory using the docs environment:
+
+```bash
+julia --project=. make.jl
+```
+
+Or equivalently from the repo root:
+
+```bash
+julia --project=docs docs/make.jl
+```
+
+Documenter.jl will write the rendered HTML to `docs/build/`. Open `docs/build/index.html` in a browser to view the result.
+
+The warning:
+
+```text
+┌ Warning: Documenter could not auto-detect the building environment. Skipping deployment.
+└ @ Documenter ~/.julia/packages/Documenter/AXNMp/src/deployconfig.jl:93
+```
+
+is expected — `deploydocs` only activates in CI (GitHub Actions) and is safe to ignore when building locally.

--- a/docs/src/dev/contributing.md
+++ b/docs/src/dev/contributing.md
@@ -1,0 +1,46 @@
+## Contributing
+
+Additions to Lincege are welcome in the following forms:
+
+1. **Issues** – Report bugs or suggest new features.
+2. **Pull Requests** – Submit code changes or documentation updates.
+
+Please ensure all your edits pass the local tests located in `test/runtests.jl` before submitting.
+
+### Pull Request Process
+
+We use the feature branch workflow for contributions. Please follow these steps:
+
+1. **Fork the Repository**
+   Fork the Lincege repository to your own GitHub account.
+
+2. **Clone Locally**
+   Clone your fork to your computer and navigate into the directory:
+   ```bash
+   git clone https://github.com
+   cd Lincege.jl
+   ```
+
+3. **Create a Feature Branch**
+   Create a new branch for your specific changes. Use a descriptive name:
+   ```bash
+   git checkout -b feature/your-feature-name
+   ```
+
+4. **Make Changes and Test**
+   Implement your changes. Ensure everything works by running the tests:
+   ```julia
+   using Pkg; Pkg.test("Lincege")
+   ```
+   *(Alternatively, run `julia test/runtests.jl` from your terminal)*
+
+5. **Commit and Push**
+   Commit your changes with clear messages and push the branch to your fork:
+   ```bash
+   git add .
+   git commit -m "Add a brief description of your changes"
+   git push origin feature/your-feature-name
+   ```
+
+6. **Open a Pull Request**
+   Go to the original Lincege repository on GitHub. Click **New Pull Request** and select your feature branch to submit.


### PR DESCRIPTION
Closes #34 

This sneaks in a personal preference that I'm willing to back off of, but it was odd to me that each page had an index.html rather than being in the organization scheme that more reflected the pages Dict. This meant, at least for me, the landing page for each section was an index file pointing to the markdown file, rather than just rendering the markdown file (i.e. two clicks to get to the actual page, and rather ugly). 

<img width="913" height="236" alt="image" src="https://github.com/user-attachments/assets/ac63024b-ef2d-41dd-942f-9147bd6a9728" />

Turning off prettyurls "solved" this for me so that you can just click each section in the dropdown, which behaves like all the other doc pages for packages I've used (the main [Julia docs ](https://docs.julialang.org/en/v1/) being a good example). 

Now if this breaks anything CI related then potentially prettyurls can go back on, but it confused me that there were so many index.htmls.

The development sections do still need something that nods to JuliaFormatter, but I really do like the pre-commit/commit hook idea.